### PR TITLE
Add homeassistant module

### DIFF
--- a/terraform/modules/homeassistant/data.tf
+++ b/terraform/modules/homeassistant/data.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "account" {}
+data "aws_region" "current" {}

--- a/terraform/modules/homeassistant/eips.tf
+++ b/terraform/modules/homeassistant/eips.tf
@@ -1,0 +1,7 @@
+resource "aws_eip" "ha_instance" {
+  domain = "vpc"
+
+  tags = {
+    Name = "ha-instance-eip"
+  }
+}

--- a/terraform/modules/homeassistant/files/cloud-init.sh
+++ b/terraform/modules/homeassistant/files/cloud-init.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+
+DOCKER_COMPOSE_FILE='/root/docker-compose.yaml'
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y upgrade
+
+# Install a few prerequisites.
+apt-get install -y \
+    jq \
+    unzip
+
+# Install the awscli. Install from the zip file because the
+# packaged version in Jammy is too old.
+curl -o awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip
+curl -o awscliv2.sig https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip.sig
+gpg --import <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+ZMKcEgUJCSEf3QAKCRCmMQrMRnJHXCilD/4vior9J5tB+icri5WbDudS3ak/ve4q
+XS6ZLm5S8l+CBxy5aLQUlyFhuaaEHDC11fG78OduxatzeHENASYVo3mmKNwrCBza
+NJaeaWKLGQT0MKwBSP5aa3dva8P/4oUP9GsQn0uWoXwNDWfrMbNI8gn+jC/3MigW
+vD3fu6zCOWWLITNv2SJoQlwILmb/uGfha68o4iTBOvcftVRuao6DyqF+CrHX/0j0
+klEDQFMY9M4tsYT7X8NWfI8Vmc89nzpvL9fwda44WwpKIw1FBZP8S0sgDx2xDsxv
+L8kM2GtOiH0cHqFO+V7xtTKZyloliDbJKhu80Kc+YC/TmozD8oeGU2rEFXfLegwS
+zT9N+jB38+dqaP9pRDsi45iGqyA8yavVBabpL0IQ9jU6eIV+kmcjIjcun/Uo8SjJ
+0xQAsm41rxPaKV6vJUn10wVNuhSkKk8mzNOlSZwu7Hua6rdcCaGeB8uJ44AP3QzW
+BNnrjtoN6AlN0D2wFmfE/YL/rHPxU1XwPntubYB/t3rXFL7ENQOOQH0KVXgRCley
+sHMglg46c+nQLRzVTshjDjmtzvh9rcV9RKRoPetEggzCoD89veDA9jPR2Kw6RYkS
+XzYm2fEv16/HRNYt7hJzneFqRIjHW5qAgSs/bcaRWpAU/QQzzJPVKCQNr4y0weyg
+B8HCtGjfod0p1A==
+=gdMc
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+gpg --verify awscliv2.sig awscliv2.zip
+unzip awscliv2.zip && ./aws/install
+
+# Associate Elastic IP.
+aws --region ${region} ec2 associate-address \
+     --allocation-id ${eip_id} \
+     --instance-id $(ec2metadata --instance-id)
+
+# Wait a few seconds for the EIP to come up.
+sleep 5
+
+# Attach EBS data volumes. We have to do this here because we're using
+# an ASG and launch templates don't allow attaching specific volumes.
+aws --region ${region} ec2 attach-volume \
+     --device /dev/sdf \
+     --instance-id $(ec2metadata --instance-id) \
+     --volume-id ${ha_volume_id}
+
+aws --region ${region} ec2 attach-volume \
+     --device /dev/sdg \
+     --instance-id $(ec2metadata --instance-id) \
+     --volume-id ${mosquitto_volume_id}
+
+# Give the OS a few seconds to create devices for the above volumes.
+sleep 5
+
+# Create partitions and filesystems if volumes are new.
+for vol in /dev/nvme1n1 /dev/nvme2n1; do
+  blkid $${vol} > /dev/null && true
+  if [ "$?" != "0" ]; then
+    /sbin/parted $${vol} mklabel gpt --script
+    /sbin/parted $${vol} mkpart primary 0% 100% --script
+    # Wait a second for the block device to appear.
+    sleep 1
+    mkfs.ext4 $${vol}p1
+  fi
+done
+
+echo '/dev/nvme1n1p1	/etc/homeassistant	ext4	defaults	0	0' >> /etc/fstab
+echo '/dev/nvme2n1p1	/var/lib/mosquitto	ext4	defaults	0	0' >> /etc/fstab
+
+# Create mount points.
+mkdir -p /etc/homeassistant /var/lib/mosquitto
+
+# Mount partitions.
+mount -a
+
+apt-get install --yes docker-compose
+
+# Add the ubuntu user to the docker group.
+usermod -a -G docker ubuntu
+
+# Create docker-compose file.
+cat > $DOCKER_COMPOSE_FILE <<EOF
+version: "3.1"
+services:
+  mosquitto:
+    image: eclipse-mosquitto
+    container_name: mosquitto
+    restart: unless-stopped
+    volumes:
+      - /var/lib/mosquitto:/mosquitto
+      - /var/lib/mosquitto/data:/mosquitto/data
+      - /var/lib/mosquitto/log:/mosquitto/log
+    ports:
+      - 1883:1883
+      - 8883:8883
+      - 9001:9001
+  homeassistant:
+    container_name: homeassistant
+    image: "ghcr.io/home-assistant/home-assistant:stable"
+    volumes:
+      - /etc/homeassistant:/config
+    environment:
+      - TZ="Europe/London"
+    restart: unless-stopped
+    privileged: true
+    ports:
+      - 8123:8123
+  nginx:
+    container_name: nginx
+    image: nginx:latest
+    user: root
+    ports:
+      - 80:80
+      - 443:443
+    restart: unless-stopped
+    volumes:
+      - /etc/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /etc/nginx/conf.d:/etc/nginx/conf.d:ro
+      - /etc/certbot/www:/var/www/certbot:ro
+      - /etc/certbot/conf:/etc/nginx/ssl:ro
+  certbot:
+    image: certbot/certbot:latest
+    volumes:
+      - /etc/certbot/www/:/var/www/certbot/:rw
+      - /etc/certbot/conf/:/etc/letsencrypt/:rw
+EOF
+
+# Create mosquitto directory structure
+mkdir -p /var/lib/mosquitto/{config,data,log,tls}
+
+# Create directories for nginx and certbot config
+mkdir -p /etc/nginx/conf.d /etc/certbot/{conf,www}
+
+# Create an initial port 80 nginx config so that certbot can complete the
+# validation step for a new certificate from LetsEncrypt
+cat > /etc/nginx/nginx.conf <<EOF
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
+                      '\$status \$body_bytes_sent "\$http_referer" '
+                      '"\$http_user_agent" "\$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    keepalive_timeout  65;
+    map \$http_upgrade \$connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+    include /etc/nginx/conf.d/*.conf;
+}
+EOF
+
+cat > /etc/nginx/conf.d/homeassistant_80.conf <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name ${server_name};
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+EOF
+
+# Start the services
+docker-compose -f $DOCKER_COMPOSE_FILE up -d
+
+# Request a new TLS certificate from LetsEncrypt
+# Specify a key type of 'rsa' as tasmota doesn't work with ECDSA
+docker-compose -f $DOCKER_COMPOSE_FILE run \
+               --rm certbot certonly \
+               --webroot \
+               --webroot-path /var/www/certbot/ \
+               -d ${server_name} \
+               -d ${mqtt_server_name} \
+               -m ${letsencrypt_email} \
+               --no-eff-email \
+               --agree-tos \
+               --key-type rsa \
+               ${certbot_extra_args}
+
+# Now that we have a TLS cert, create an HTTPS server in nginx
+cat > /etc/nginx/conf.d/homeassistant_443.conf <<EOF
+server {
+    listen 443 default_server ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name ${server_name};
+
+    ssl_certificate /etc/nginx/ssl/live/${server_name}/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/${server_name}/privkey.pem;
+
+    location / {
+        proxy_pass http://homeassistant:8123;
+        proxy_set_header Host \$host;
+        proxy_redirect http:// https://;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+    }
+}
+EOF
+
+# Copy the certs to a location mosquitto can use them.
+# Change ownership to the mosquito UID/GID so mosquitto can read them.
+cp -p /etc/certbot/conf/live/${server_name}/{cert.pem,privkey.pem,chain.pem} /var/lib/mosquitto/tls/
+chown 1883:1883 /var/lib/mosquitto/tls/*.pem
+
+# Create a mosquitto config
+cat > /var/lib/mosquitto/config/mosquitto.conf <<EOF
+persistence true
+persistence_location /mosquitto/data/
+persistent_client_expiration 14d
+log_dest file /mosquitto/log/mosquitto.log
+per_listener_settings true
+
+# A non-TLS listener for local clients
+listener 1883
+allow_anonymous true
+
+listener 8883
+cafile /mosquitto/tls/chain.pem
+certfile /mosquitto/tls/cert.pem
+keyfile /mosquitto/tls/privkey.pem
+allow_anonymous true
+EOF
+
+# Finally, restart the nginx and mosquitto containers
+docker-compose -f $DOCKER_COMPOSE_FILE restart nginx mosquitto
+

--- a/terraform/modules/homeassistant/gateways.tf
+++ b/terraform/modules/homeassistant/gateways.tf
@@ -1,0 +1,8 @@
+resource "aws_internet_gateway" "gateway" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name        = "${local.resource_name}-gateway"
+    Environment = "${var.environment}"
+  }
+}

--- a/terraform/modules/homeassistant/iam.tf
+++ b/terraform/modules/homeassistant/iam.tf
@@ -1,0 +1,85 @@
+resource "aws_iam_role" "instance" {
+  name = "${local.resource_name}-instance-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "instance_ssm" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_policy" "attach_volume" {
+  name        = "${local.resource_name}_attach_volume_policy"
+  path        = "/"
+  description = "An IAM policy that allows instances to attach specific EBS volumes"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:AttachVolume"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.account.account_id}:instance/*",
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.account.account_id}:volume/${aws_ebs_volume.ha_data.id}",
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.account.account_id}:volume/${aws_ebs_volume.mosquitto_data.id}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "attach_volume" {
+  role       = aws_iam_role.instance.name
+  policy_arn = aws_iam_policy.attach_volume.arn
+}
+
+resource "aws_iam_policy" "associate_address" {
+  name        = "${local.resource_name}_associate_address_policy"
+  path        = "/"
+  description = "An IAM policy that allows instances to associate elastic IP addresses"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:AssociateAddress"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "associate_address" {
+  role       = aws_iam_role.instance.name
+  policy_arn = aws_iam_policy.associate_address.arn
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${local.resource_name}-instance-profile"
+  role = aws_iam_role.instance.name
+}

--- a/terraform/modules/homeassistant/instance.tf
+++ b/terraform/modules/homeassistant/instance.tf
@@ -1,0 +1,88 @@
+data "aws_ami" "ami" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"]
+  }
+}
+
+resource "aws_launch_template" "ha_instance" {
+  name_prefix = "${local.resource_name}-ha-instance"
+  image_id    = data.aws_ami.ami.id
+  key_name    = var.instance_key_name
+  user_data = base64encode(templatefile(
+    "${path.module}/files/cloud-init.sh",
+    {
+      environment         = var.environment,
+      region              = data.aws_region.current.name,
+      ha_volume_id        = aws_ebs_volume.ha_data.id,
+      mosquitto_volume_id = aws_ebs_volume.mosquitto_data.id,
+      eip_id              = aws_eip.ha_instance.id
+      server_name         = var.server_name
+      mqtt_server_name    = var.mqtt_server_name
+      letsencrypt_email   = var.letsencrypt_email
+      certbot_extra_args  = var.certbot_extra_args
+    }
+  ))
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.instance.arn
+  }
+
+  network_interfaces {
+    delete_on_termination       = true
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.ha_instance.id]
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+}
+
+resource "aws_autoscaling_group" "asg" {
+  name                = "${local.resource_name}-asg"
+  vpc_zone_identifier = [element(aws_subnet.public.*.id, 0)]
+  desired_capacity    = 1
+  max_size            = 1
+  min_size            = 1
+
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_base_capacity                  = 0
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "lowest-price"
+      spot_instance_pools                      = length(local.spot_instance_types)
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.ha_instance.id
+        version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = local.spot_instance_types
+
+        content {
+          instance_type = override.value
+        }
+      }
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${local.resource_name}-instance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+}

--- a/terraform/modules/homeassistant/outputs.tf
+++ b/terraform/modules/homeassistant/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id" {
+  value = aws_vpc.vpc.id
+}

--- a/terraform/modules/homeassistant/route53.tf
+++ b/terraform/modules/homeassistant/route53.tf
@@ -1,0 +1,17 @@
+resource "aws_route53_record" "ha" {
+  count   = var.add_dns_record
+  zone_id = var.dns_zone_id
+  name    = local.resource_name
+  type    = local.dns_record_type
+  ttl     = local.dns_record_ttl
+  records = [aws_eip.ha_instance.public_ip]
+}
+
+resource "aws_route53_record" "mqtt" {
+  count   = var.add_dns_record
+  zone_id = var.dns_zone_id
+  name    = var.mqtt_server_name
+  type    = local.dns_record_type
+  ttl     = local.dns_record_ttl
+  records = [aws_eip.ha_instance.public_ip]
+}

--- a/terraform/modules/homeassistant/routing.tf
+++ b/terraform/modules/homeassistant/routing.tf
@@ -1,0 +1,20 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name        = "${local.resource_name}-public-rt"
+    Environment = var.environment
+  }
+}
+
+resource "aws_route" "public_default" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gateway.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = local.az_count
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
+}

--- a/terraform/modules/homeassistant/security_groups.tf
+++ b/terraform/modules/homeassistant/security_groups.tf
@@ -1,0 +1,63 @@
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_security_group" "ha_instance" {
+  name_prefix = "${local.resource_name}-instance-sg"
+  vpc_id      = aws_vpc.vpc.id
+  description = "Security group for Home Assistant instances"
+
+  tags = {
+    Name = "${local.resource_name}-instance-sg"
+  }
+}
+
+resource "aws_security_group_rule" "ingress_http" {
+  security_group_id = aws_security_group.ha_instance.id
+  type              = "ingress"
+  description       = "Allow ingress to tcp/80 from everywhere"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+}
+
+resource "aws_security_group_rule" "ingress_https" {
+  security_group_id = aws_security_group.ha_instance.id
+  type              = "ingress"
+  description       = "Allow ingress to tcp/443 from everywhere"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+}
+
+resource "aws_security_group_rule" "ingress_mqtt" {
+  security_group_id = aws_security_group.ha_instance.id
+  type              = "ingress"
+  description       = "Allow ingress to tcp/8883 from everywhere"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 8883
+  to_port           = 8883
+  protocol          = "tcp"
+}
+
+resource "aws_security_group_rule" "egress_http" {
+  security_group_id = aws_security_group.ha_instance.id
+  type              = "egress"
+  description       = "Allow egress to tcp/80"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+}
+
+resource "aws_security_group_rule" "egress_https" {
+  security_group_id = aws_security_group.ha_instance.id
+  type              = "egress"
+  description       = "Allow egress to tcp/443"
+  cidr_blocks       = ["0.0.0.0/0"]
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+}

--- a/terraform/modules/homeassistant/subnets.tf
+++ b/terraform/modules/homeassistant/subnets.tf
@@ -1,0 +1,13 @@
+data "aws_availability_zones" "azs" {}
+
+resource "aws_subnet" "public" {
+  count             = local.az_count
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = element(data.aws_availability_zones.azs.names, count.index)
+  cidr_block        = cidrsubnet(aws_vpc.vpc.cidr_block, 8, count.index)
+
+  tags = {
+    Name        = "subnet-public-${count.index}"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/homeassistant/variables.tf
+++ b/terraform/modules/homeassistant/variables.tf
@@ -1,0 +1,44 @@
+variable "environment" {
+  description = "Name of the environment, eg. staging, prod etc"
+}
+
+variable "dns_zone_id" {
+  description = "Route53 zone ID to add a record to for the instance"
+}
+
+variable "add_dns_record" {
+  description = "Whether to add a route53 DNS record to dns_zone_id resolving to the EIP address"
+  default     = 1
+}
+
+variable "server_name" {
+  description = "The hostname of the home assistant site"
+}
+
+variable "mqtt_server_name" {
+  description = "The DNS name of the mosquitto server"
+}
+
+variable "letsencrypt_email" {
+  description = "Email address to register with LetsEncrypt when requesting certificates"
+}
+
+variable "certbot_extra_args" {
+  description = "Extra args to pass to certbot when creating TLS certificates"
+  default     = "--test-cert"
+}
+
+variable "instance_key_name" {
+  description = "Name of the key pair to use for EC2 instances"
+  default     = ""
+}
+
+locals {
+  az_count      = 1
+  resource_name = "homeassistant"
+
+  dns_record_ttl  = "86400"
+  dns_record_type = "A"
+
+  spot_instance_types = ["t4g.micro", "t4g.small"]
+}

--- a/terraform/modules/homeassistant/volumes.tf
+++ b/terraform/modules/homeassistant/volumes.tf
@@ -1,0 +1,23 @@
+resource "aws_ebs_volume" "ha_data" {
+  availability_zone = element(data.aws_availability_zones.azs.names, 0)
+  encrypted         = true
+  size              = 5
+  type              = "gp3"
+
+  tags = {
+    Name        = "homeassistant data volume"
+    Environment = var.environment
+  }
+}
+
+resource "aws_ebs_volume" "mosquitto_data" {
+  availability_zone = element(data.aws_availability_zones.azs.names, 0)
+  encrypted         = true
+  size              = 1
+  type              = "gp3"
+
+  tags = {
+    Name        = "mosquitto data volume"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/homeassistant/vpc.tf
+++ b/terraform/modules/homeassistant/vpc.tf
@@ -1,0 +1,10 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name        = local.resource_name
+    Environment = var.environment
+  }
+}


### PR DESCRIPTION
Add a homeassistant module that provisions a Home Assistant server on an EC2 spot instance, as well as a Mosquitto MQTT broker and an Nginx proxy. These are deployed as docker containers using docker-compose.

The spot instance is part of an autoscaling group with a desired capacity of 1 to make sure the instance is recreated if the spot instance is reclaimed by AWS.

This also creates a valid TLS sertificate for Nginx and Mosquitto using LetsEncrypt. The cert will be recreated each time the instance is recreated.